### PR TITLE
Fix link to interfaces screenshot

### DIFF
--- a/guides/Debian-en.md
+++ b/guides/Debian-en.md
@@ -263,7 +263,7 @@ To try and mitigate this, so that only SSH is being used as a valid socket, you 
 # route -n
 ```
 
-Now, edit the file `/etc/network/interfaces`so it looks like [this](screeshots/d60.png).
+Now, edit the file `/etc/network/interfaces`so it looks like [this](screenshots/d60.png).
 
 Now, list the sockets available again.
 


### PR DESCRIPTION
There is a link in the SSH section that was supposed to redirect to a screenshot showing the expected `etc/network/interfaces` file. This link is missing a 'n' in it's path, and therefore, is broken.